### PR TITLE
FEATURE: add the new 4.1 models from OpenAI

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -17,9 +17,11 @@ plugins:
   ai_topic_summary_open_ai_model:
     client: false
     type: enum
-    default: gpt-4o-mini
+    default: gpt-4.1-mini
     choices:
-      - gpt-3.5-turbo
+      - gpt-4.1
+      - gpt-4.1-mini
+      - gpt-4.1-nano
       - gpt-4o
       - gpt-4o-mini
       - gpt-4-turbo

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-ai-topic-summary
 # about: Uses a remote (OpenAI) AI language model to prepare and post a summary of a Topic
-# version: 0.5.4
+# version: 0.5.5
 # authors: Robert Barrow
 # contact_emails: merefield@gmail.com
 # url: https://github.com/merefield/discourse-ai-topic-summary


### PR DESCRIPTION
* adds `gpt-4.1`, `gpt-4.1-mini` and `gpt-4.1-nano` notable for cheaper pricing and hugely increased context windows.
* removes `gpt-3.5-turbo`

see https://openai.com/index/gpt-4-1/